### PR TITLE
install helm diff

### DIFF
--- a/tasks/helm_diff.yml
+++ b/tasks/helm_diff.yml
@@ -1,0 +1,10 @@
+---
+- name: check if helm diff plugin is present
+  ansible.builtin.shell: helm plugin list 2>/dev/null |grep ^diff
+  register: helm_diff_plugin
+  changed_when: false
+  failed_when: "helm_diff_plugin.rc not in [ 0, 1 ]"
+
+- name: install helm diff
+  ansible.builtin.shell: helm plugin install https://github.com/databus23/helm-diff
+  when: not ansible_check_mode and helm_diff_plugin.rc != 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,3 +2,7 @@
 - name: install helm
   include: helm.yml
   tags: helm
+
+- name: install helm
+  include: helm_diff.yml
+  tags: helm, helm_diff


### PR DESCRIPTION
During CZERTAINLY installation via helm, helm recommends to install this plugin for better compatibility with Ansible. 

closes #4 